### PR TITLE
mongodb variable connection verfication

### DIFF
--- a/server/config/connection.mjs
+++ b/server/config/connection.mjs
@@ -1,12 +1,24 @@
-// mongooseConnection.mjs (ES module syntax)
+// connection.mjs
 import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+dotenv.config();
+const MONGODB_URI = process.env.MONGODB_URI;
 
-mongoose.connect(
-  process.env.MONGODB_URI || "mongodb://127.0.0.1:27017/BrewDOCS",
-  {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-  }
+mongoose.connect(MONGODB_URI || "mongodb://127.0.0.1:27017/BrewDOCS",
+{
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+}
 );
 
-export default mongoose.connection;
+const connection = mongoose.connection;
+
+connection.on('error', (error) => {
+  console.error('MongoDB connection error:', error);
+});
+
+connection.once('open', () => {
+  console.log('Connected to MongoDB');
+});
+
+export { connection as mongooseConnection };

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -5,9 +5,10 @@ import { ApolloServer } from 'apollo-server-express';
 import { ApolloServerPluginDrainHttpServer, ApolloServerPluginLandingPageLocalDefault } from 'apollo-server-core';
 import express from 'express';
 import http from 'http';
-import mongooseConnection from './config/connection.mjs'; // Update the path
-
+import { mongooseConnection } from './config/connection.mjs'; // Update the path
 import { typeDefs, resolvers } from './schema/index.mjs';
+
+
 
 const PORT = process.env.PORT || 4000;
 


### PR DESCRIPTION
setup dotenv variable to bypass async server.  Now we can use a local mongodb with compass by commenting out your personal .env variable.  That will access your local mongodb compass and apollo server.  Using the correct .env variable MONGODB_URI will direct all work to the mongodb atlas that is served in the cloud.