### PR TITLE
started fix on ingredientsList resolvers, typeDefs, and models

### DIFF
--- a/server/graphql/resolvers/ingredientsListResolvers.mjs
+++ b/server/graphql/resolvers/ingredientsListResolvers.mjs
@@ -4,14 +4,22 @@ import IngredientsList from "../../models/IngredientsList.mjs";
 
 export const ingredientsListResolvers = {
   Query: {
+    // these are for admin use and should NOT be used in the client
+    getAllIngredientsList: async () => {
+      return await IngredientsList.find({});
+    },
     getIngredients: async (_, { id }) => {
       return await IngredientsList.findById(id);
     },
-    getAllIngredients: async () => {
-      return await IngredientsList.find({});
-    },
   },
   Mutation: {
+    // these are for admin use and should NOT be used in the client
+    addIngredientsList: async (_, { name }) => {
+      const ingredientsList = await IngredientsList.create({
+        name,
+      });
+      return ingredientsList;
+    },
     addToIngredientsList: async (
       _,
       { malt, water, hops, yeast, additives }

--- a/server/graphql/typedefs/ingredientsListTypeDefs.mjs
+++ b/server/graphql/typedefs/ingredientsListTypeDefs.mjs
@@ -3,8 +3,9 @@
 import { gql } from "apollo-server-express";
 
 export const ingredientsListTypeDefs = gql`
-  type Ingredients {
+  type IngredientsList {
     id: ID!
+    name: String!
     malt: [Malt]
     water: [Water]
     hops: [Hops]
@@ -14,17 +15,21 @@ export const ingredientsListTypeDefs = gql`
   }
 
   type Query {
-    getIngredients(id: ID!): Ingredients
-    getAllIngredients: [Ingredients]
+    getAllIngredientsList: [IngredientsList]
+    getIngredients(id: ID!): IngredientsList
   }
 
   type Mutation {
+    # these are for admin use and should NOT be used in the client
+    addIngredientsList(
+      name: String!
+    ): IngredientsList
     addToIngredientsList(
       malt: [ID!]!
       water: [ID!]!
       hops: [ID!]!
       yeast: [ID!]!
       additives: [ID!]!
-    ): Ingredients
+    ): IngredientsList
   }
 `;

--- a/server/models/IngredientsList.mjs
+++ b/server/models/IngredientsList.mjs
@@ -2,7 +2,11 @@
 
 import { Schema, model } from "mongoose";
 
-const ingredientsSchema = new Schema({
+const ingredientsListSchema = new Schema({
+  name: {
+    type: String,
+    required: true,
+  },
   malt: [
     {
       type: Schema.Types.ObjectId,
@@ -39,6 +43,6 @@ const ingredientsSchema = new Schema({
   },
 });
 
-const Ingredients = model("Ingredients", ingredientsSchema);
+const IngredientsList = model("IngredientsList", ingredientsListSchema);
 
-export default Ingredients;
+export default IngredientsList;


### PR DESCRIPTION
I started the fix on this.  The major issue was the naming has to be the same across the board on these things.  The other element is trying to do too many things at once.  We want to create an object, we don't need to create everything in that object at once. the framework of the object is handled in the model. The mutation only needs a single reference point to be built, in this case name. the framework for the other arrays is there implicitly by the model work.